### PR TITLE
Bug fix: Restrict to one record

### DIFF
--- a/base.php
+++ b/base.php
@@ -57,10 +57,10 @@ function getChoices($metadata) {
 	return $choices;
 }
 
-function searchForTerms($pid, $eventId, $terms) {
+function searchForTerms($pid, $eventId, $terms, $record) {
     $fields = ["record_id", "grants_number", "grants_pi", "grants_abstract", "grants_thesaurus", "grants_file"];
     $fieldsToInspect = ["grants_abstract" => "Abstract", "grants_thesaurus" => "Terms or Public Health Relevance"];
-    $redcapData = \REDCap::getData($pid, "json-array", NULL, $fields);
+    $redcapData = \REDCap::getData($pid, "json-array", [$record], $fields);
 
     $foundItems = [];
     foreach ($terms as $term) {

--- a/saveHook.php
+++ b/saveHook.php
@@ -31,7 +31,7 @@ $searchTerms = [
     "Program Evaluation",
 ];
 $to = "robyn.tamboli@vumc.org,isaac.schlotterbeck@vumc.org";
-$foundItems = searchForTerms($grantsProjectId, $event_id, $searchTerms);
+$foundItems = searchForTerms($grantsProjectId, $event_id, $searchTerms, $record);
 if (!empty($foundItems)) {
     $html = "<h1>Grant Repository Record $record</h1><p><strong>Search Terms: </strong>".implode(", ", $searchTerms)."</p>".makeSearchHTML($foundItems);
     \REDCap::email($to, "noreply.grantRepository@vumc.org", "Grant Repository matches for CCQIR", $html);


### PR DESCRIPTION
The Grant Repository stores all Vanderbilt grant applications over time for collegial reuse in new applications. Recently, CFIR requested an alert whenever a new application was added with a given list of terms, like Implementation Science, Implementation Research, or Quality Improvement. Today, Robyn Tamboli requested that this alert be limited to only one record, the new record being saved, instead of all records. This simple fix implements that request.